### PR TITLE
Calculate tiles sizes based on parent element width

### DIFF
--- a/js/metroInit.js
+++ b/js/metroInit.js
@@ -25,7 +25,7 @@ UIFreewallVertical = (function() {
       selector: '.panels',
       cellW: function() {
 
-        var width = $('body').width();
+        var width = $('[data-metro-id="' + data.id + '"]:not([data-mce-bogus] [data-metro-id="' + data.id + '"])').parent().width();
 
         if (width >= 1300) {
           cellWidth = 330;
@@ -49,7 +49,7 @@ UIFreewallVertical = (function() {
       },
       cellH: function() {
 
-        var width = $('body').width();
+        var width = $('[data-metro-id="' + data.id + '"]:not([data-mce-bogus] [data-metro-id="' + data.id + '"])').parent().width();
 
         if (width >= 1300) {
           cellHeight = 330;


### PR DESCRIPTION
Issue ref: https://github.com/Fliplet/fliplet-studio/issues/4594

<img width="816" alt="Screenshot 2019-07-10 at 12 46 01" src="https://user-images.githubusercontent.com/7046481/60966685-b1d76b80-a310-11e9-91d3-344c9afd21ec.png">

- Changed to calculate tile sizes based on Grid's parent element width, instead of `body` width.
  - More information: https://github.com/Fliplet/fliplet-studio/issues/4594#issuecomment-510025322