### PR TITLE
Allow user to save widget after dismissing file picker

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -294,6 +294,7 @@ function initImageProvider(item) {
         $('[data-id="' + item.id + '"] .add-image-holder').find('.thumb-holder').addClass('hidden');
       }
 
+      Fliplet.Widget.resetSaveButtonLabel();
       imageProvider = null;
     }
   });

--- a/js/interface.js
+++ b/js/interface.js
@@ -288,10 +288,13 @@ function initImageProvider(item) {
     if (event.data === 'cancel-button-pressed') {
       Fliplet.Widget.toggleCancelButton(true);
       imageProvider.close();
+      
       if (_.isEmpty(item.imageConf)) {
         $('[data-id="' + item.id + '"] .add-image-holder').find('.add-image').text('Add image');
         $('[data-id="' + item.id + '"] .add-image-holder').find('.thumb-holder').addClass('hidden');
       }
+
+      imageProvider = null;
     }
   });
 


### PR DESCRIPTION
@tonytlwu @squallstar @sofiiakvasnevska 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/5215

## Description
Allow user to save widget after dismissing file picker

## Screenshots/screencasts
![issue5015](https://user-images.githubusercontent.com/53430352/68658360-f765a880-053d-11ea-9549-32372ee60b71.gif)

## Backward compatibility

This change is fully backward compatible.