### PR TITLE
Grid resizing now works correctly when user switches preview device

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -1,4 +1,4 @@
-window.ui = window.ui || {}
+window.ui = window.ui || {};
 ui.uiFreewallVertical = {};
 
 Fliplet.Widget.instance('metro', function (data) {
@@ -25,7 +25,7 @@ Fliplet.Widget.instance('metro', function (data) {
     $container.on('click', '.linked[data-metro-item-id]', function (event) {
       event.preventDefault();
 
-      var itemID = $(this).data('metro-item-id')
+      var itemID = $(this).data('metro-item-id');
       var itemData = _.find(data.items, { id: itemID });
 
       if (!_.isUndefined(_.get(itemData, 'linkAction'))

--- a/js/metroInit.js
+++ b/js/metroInit.js
@@ -65,7 +65,7 @@ UIFreewallVertical = (function() {
         } else if (width >= 1200) {
           cellHeight = 310;
           return cellHeight;
-        } else if (width >= 1014) {
+        } else if (width >= 1024) {
           cellHeight = 230;
           return cellHeight;
         } else if (width >= 640) {
@@ -82,6 +82,7 @@ UIFreewallVertical = (function() {
       gutterY: data.enableGap ? 10 : 0,
       gutterX: data.enableGap ? 10 : 0,
       rightToLeft: $('html[dir="rtl"]').length ? true : false,
+      cacheSize: false,
       onResize: function() {
         wall.fitWidth();
       }


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5523

## Description
Freewall library kept cell sizes until page reload. Added cacheSize: false to prevent it.

## Screenshots/screencasts
![grid-fix](https://user-images.githubusercontent.com/52824207/75861536-38900a00-5e06-11ea-81fd-c5ac988aa5ab.gif)

## Backward compatibility
This change is fully backward compatible.