### PR TITLE
Grid on desktop screen now works correctly

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -189,7 +189,7 @@
 
   .panels.size21 {
     width: 630px;
-    height: 330px;
+    height: 310px;
   }
 
   .panels.size22 {

--- a/js/metroInit.js
+++ b/js/metroInit.js
@@ -19,6 +19,13 @@ UIFreewallVertical = (function() {
 
     // Resize handler
     window.addEventListener('resize', UIFreewallVertical.setupFreewalVertical(data), false);
+
+    // Reload desktop screen
+    window.addEventListener('message', function(event) {
+      if (event.data.event === 'set-preview-device' && event.data.platform === 'web') {
+        Fliplet.Widget.emit('reload-widget-instance');
+      }
+    });
   }
 
   UIFreewallVertical.loadMetro = function() {


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5523

## Description
Added reload-widget-instance when navigating to desktop device. I did not add this event on mobile and tablet as they seem to work correctly.

## Screenshots/screencasts
![grid](https://user-images.githubusercontent.com/52824207/77432564-e891db00-6de6-11ea-917f-8f6af4299c5c.gif)

## Backward compatibility
This change is fully backward compatible.