### PR TITLE
Grid now assigns correct sizes if grid component is inside container

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -213,6 +213,97 @@
     height: 670px;
   }
 }
+
+.panel-container-initial.panels.size11 {
+  width: 140px;
+  height: 140px;
+}
+
+.panel-container-initial.panels.size21 {
+  width: 290px;
+  height: 140px;
+}
+
+.panel-container-initial.panels.size22 {
+  width: 290px;
+  height: 290px;
+}
+
+.panel-container-400.panels.size11 {
+  width: 155px;
+  height: 155px;
+}
+
+.panel-container-400.panels.size21 {
+  width: 320px;
+  height: 155px;
+}
+
+.panel-container-400.panels.size22 {
+  width: 320px;
+  height: 320px;
+}
+
+.panel-container-640.panels.size11 {
+  width: 185px;
+  height: 185px;
+}
+
+.panel-container-640.panels.size21 {
+  width: 380px;
+  height: 185px;
+}
+
+.panel-container-640.panels.size22 {
+  width: 380px;
+  height: 380px;
+}
+
+.panel-container-1024.panels.size11 {
+  width: 230px;
+  height: 230px;
+}
+
+.panel-container-1024.panels.size21 {
+  width: 470px;
+  height: 230px;
+}
+
+.panel-container-1024.panels.size22 {
+  width: 470px;
+  height: 470px;
+}
+
+.panel-container-1200.panels.size11 {
+  width: 310px;
+  height: 310px;
+}
+
+.panel-container-1200.panels.size21 {
+  width: 630px;
+  height: 310px;
+}
+
+.panel-container-1200.panels.size22 {
+  width: 630px;
+  height: 630px;
+}
+
+.panel-container-1300.panels.size11 {
+  width: 330px;
+  height: 330px;
+}
+
+.panel-container-1300.panels.size21 {
+  width: 670px;
+  height: 330px;
+}
+
+.panel-container-1300.panels.size22 {
+  width: 670px;
+  height: 670px;
+}
+
 @media (max-width: 399px) {
   .metro-panels .metro-desc p {
     font-size: 14px;

--- a/css/build.css
+++ b/css/build.css
@@ -214,92 +214,92 @@
   }
 }
 
-.panel-container-initial .panels.size11 {
+[data-container-size="initial"] .panels.size11 {
   width: 140px;
   height: 140px;
 }
 
-.panel-container-initial .panels.size21 {
+[data-container-size="initial"] .panels.size21 {
   width: 290px;
   height: 140px;
 }
 
-.panel-container-initial .panels.size22 {
+[data-container-size="initial"] .panels.size22 {
   width: 290px;
   height: 290px;
 }
 
-.panel-container-400 .panels.size11 {
+[data-container-size="400"] .panels.size11 {
   width: 155px;
   height: 155px;
 }
 
-.panel-container-400 .panels.size21 {
+[data-container-size="400"] .panels.size21 {
   width: 320px;
   height: 155px;
 }
 
-.panel-container-400 .panels.size22 {
+[data-container-size="400"] .panels.size22 {
   width: 320px;
   height: 320px;
 }
 
-.panel-container-640 .panels.size11 {
+[data-container-size="640"] .panels.size11 {
   width: 185px;
   height: 185px;
 }
 
-.panel-container-640 .panels.size21 {
+[data-container-size="640"] .panels.size21 {
   width: 380px;
   height: 185px;
 }
 
-.panel-container-640 .panels.size22 {
+[data-container-size="640"] .panels.size22 {
   width: 380px;
   height: 380px;
 }
 
-.panel-container-1024 .panels.size11 {
+[data-container-size="1024"] .panels.size11 {
   width: 230px;
   height: 230px;
 }
 
-.panel-container-1024 .panels.size21 {
+[data-container-size="1024"] .panels.size21 {
   width: 470px;
   height: 230px;
 }
 
-.panel-container-1024 .panels.size22 {
+[data-container-size="1024"] .panels.size22 {
   width: 470px;
   height: 470px;
 }
 
-.panel-container-1200 .panels.size11 {
+[data-container-size="1200"] .panels.size11 {
   width: 310px;
   height: 310px;
 }
 
-.panel-container-1200 .panels.size21 {
+[data-container-size="1200"] .panels.size21 {
   width: 630px;
   height: 310px;
 }
 
-.panel-container-1200 .panels.size22 {
+[data-container-size="1200"] .panels.size22 {
   width: 630px;
   height: 630px;
 }
 
-.panel-container-1300 .panels.size11 {
+[data-container-size="1300"] .panels.size11 {
   width: 330px;
   height: 330px;
 }
 
-.panel-container-1300 .panels.size21 {
+[data-container-size="1300"] .panels.size21 {
   width: 670px;
   height: 330px;
 }
 
-.panel-container-1300 .panels.size22 {
+[data-container-size="1300"] .panels.size22 {
   width: 670px;
   height: 670px;
 }

--- a/css/build.css
+++ b/css/build.css
@@ -214,92 +214,92 @@
   }
 }
 
-.panel-container-initial.panels.size11 {
+.panel-container-initial .panels.size11 {
   width: 140px;
   height: 140px;
 }
 
-.panel-container-initial.panels.size21 {
+.panel-container-initial .panels.size21 {
   width: 290px;
   height: 140px;
 }
 
-.panel-container-initial.panels.size22 {
+.panel-container-initial .panels.size22 {
   width: 290px;
   height: 290px;
 }
 
-.panel-container-400.panels.size11 {
+.panel-container-400 .panels.size11 {
   width: 155px;
   height: 155px;
 }
 
-.panel-container-400.panels.size21 {
+.panel-container-400 .panels.size21 {
   width: 320px;
   height: 155px;
 }
 
-.panel-container-400.panels.size22 {
+.panel-container-400 .panels.size22 {
   width: 320px;
   height: 320px;
 }
 
-.panel-container-640.panels.size11 {
+.panel-container-640 .panels.size11 {
   width: 185px;
   height: 185px;
 }
 
-.panel-container-640.panels.size21 {
+.panel-container-640 .panels.size21 {
   width: 380px;
   height: 185px;
 }
 
-.panel-container-640.panels.size22 {
+.panel-container-640 .panels.size22 {
   width: 380px;
   height: 380px;
 }
 
-.panel-container-1024.panels.size11 {
+.panel-container-1024 .panels.size11 {
   width: 230px;
   height: 230px;
 }
 
-.panel-container-1024.panels.size21 {
+.panel-container-1024 .panels.size21 {
   width: 470px;
   height: 230px;
 }
 
-.panel-container-1024.panels.size22 {
+.panel-container-1024 .panels.size22 {
   width: 470px;
   height: 470px;
 }
 
-.panel-container-1200.panels.size11 {
+.panel-container-1200 .panels.size11 {
   width: 310px;
   height: 310px;
 }
 
-.panel-container-1200.panels.size21 {
+.panel-container-1200 .panels.size21 {
   width: 630px;
   height: 310px;
 }
 
-.panel-container-1200.panels.size22 {
+.panel-container-1200 .panels.size22 {
   width: 630px;
   height: 630px;
 }
 
-.panel-container-1300.panels.size11 {
+.panel-container-1300 .panels.size11 {
   width: 330px;
   height: 330px;
 }
 
-.panel-container-1300.panels.size21 {
+.panel-container-1300 .panels.size21 {
   width: 670px;
   height: 330px;
 }
 
-.panel-container-1300.panels.size22 {
+.panel-container-1300 .panels.size22 {
   width: 670px;
   height: 670px;
 }

--- a/js/metroInit.js
+++ b/js/metroInit.js
@@ -33,55 +33,69 @@ UIFreewallVertical = (function() {
 
   UIFreewallVertical.setupFreewalVertical = function(data) {
     var wall = new freewall('[data-metro-id="' + data.id + '"]:not([data-mce-bogus] [data-metro-id="' + data.id + '"])');
-    var cellWidth;
-    var cellHeight;
+
+    function resizePanels() {
+      var containerWidth = $('[data-metro-id="' + data.id + '"]:not([data-mce-bogus] [data-metro-id="' + data.id + '"])').parent().width();
+      var $panels = $('.panels.size11, .panels.size21, .panels.size22');
+      var currentClasses = $panels.attr('class');
+      var indexOfContainerClass = currentClasses.indexOf('panel-container');
+
+      if (indexOfContainerClass > -1) {
+        var styleToRemove = currentClasses.substring(indexOfContainerClass);
+        $panels.removeClass(styleToRemove);
+      }
+
+      if (containerWidth >= 1300) {
+        $panels.addClass('panel-container-1300');
+      } else if (containerWidth >= 1200) {
+        $panels.addClass('panel-container-1200');
+      } else if (containerWidth >= 1024) {
+        $panels.addClass('panel-container-1024');
+      } else if (containerWidth >= 640) {
+        $panels.addClass('panel-container-640');
+      } else if (containerWidth >= 400) {
+        $panels.addClass('panel-container-400');
+      } else {
+        $panels.addClass('panel-container-initial');
+      }
+    }
+
+    resizePanels();
+
     wall.reset({
       selector: '.panels',
       cellW: function() {
-
         var width = $('[data-metro-id="' + data.id + '"]:not([data-mce-bogus] [data-metro-id="' + data.id + '"])').parent().width();
 
         if (width >= 1300) {
-          cellWidth = 330;
-          return cellWidth;
+          return 330;
         } else if (width >= 1200) {
-          cellWidth = 310;
-          return cellWidth;
+          return 310;
         } else if (width >= 1024) {
-          cellWidth = 230;
-          return cellWidth;
+          return 230;
         } else if (width >= 640) {
-          cellWidth = 185;
-          return cellWidth;
+          return 185;
         } else if (width >= 400) {
-          cellWidth = 155;
-          return cellWidth;
+          return 155;
         } else {
-          cellWidth = 140;
-          return cellWidth;
+          return 140;
         }
       },
       cellH: function() {
         var width = $('[data-metro-id="' + data.id + '"]:not([data-mce-bogus] [data-metro-id="' + data.id + '"])').parent().width();
 
         if (width >= 1300) {
-          cellHeight = 330;
-          return cellHeight;
+          return 330;
         } else if (width >= 1200) {
-          cellHeight = 310;
-          return cellHeight;
+          return 310;
         } else if (width >= 1024) {
-          cellHeight = 230;
-          return cellHeight;
+          return 230;
         } else if (width >= 640) {
-          cellHeight = 185;
-          return cellHeight;
+          return 185;
         } else if (width >= 400) {
-          cellHeight = 155;
-          return cellHeight;
+          return 155;
         } else {
-          cellHeight = 140;
-          return cellHeight;
+          return 140;
         }
       },
       gutterY: data.enableGap ? 10 : 0,
@@ -89,6 +103,7 @@ UIFreewallVertical = (function() {
       rightToLeft: $('html[dir="rtl"]').length ? true : false,
       cacheSize: false,
       onResize: function() {
+        resizePanels();
         wall.fitWidth();
       }
     });

--- a/js/metroInit.js
+++ b/js/metroInit.js
@@ -36,23 +36,21 @@ UIFreewallVertical = (function() {
 
     function resizePanels() {
       var $container = $('[data-metro-id="' + data.id + '"]:not([data-mce-bogus] [data-metro-id="' + data.id + '"])').parent();
-      var containerWidth = $container.width();
       var $panelsContainer = $container.find('.metro-panels ul');
-
-      $panelsContainer.removeClass();
+      var containerWidth = $container.width();
 
       if (containerWidth >= 1300) {
-        $panelsContainer.addClass('panel-container-1300');
+        $panelsContainer.attr('data-container-size', 1300);
       } else if (containerWidth >= 1200) {
-        $panelsContainer.addClass('panel-container-1200');
+        $panelsContainer.attr('data-container-size', 1200);
       } else if (containerWidth >= 1024) {
-        $panelsContainer.addClass('panel-container-1024');
+        $panelsContainer.attr('data-container-size', 1024);
       } else if (containerWidth >= 640) {
-        $panelsContainer.addClass('panel-container-640');
+        $panelsContainer.attr('data-container-size', 640);
       } else if (containerWidth >= 400) {
-        $panelsContainer.addClass('panel-container-400');
+        $panelsContainer.attr('data-container-size', 400);
       } else {
-        $panelsContainer.addClass('panel-container-initial');
+        $panelsContainer.attr('data-container-size', 'initial');
       }
     }
 

--- a/js/metroInit.js
+++ b/js/metroInit.js
@@ -35,28 +35,24 @@ UIFreewallVertical = (function() {
     var wall = new freewall('[data-metro-id="' + data.id + '"]:not([data-mce-bogus] [data-metro-id="' + data.id + '"])');
 
     function resizePanels() {
-      var containerWidth = $('[data-metro-id="' + data.id + '"]:not([data-mce-bogus] [data-metro-id="' + data.id + '"])').parent().width();
-      var $panels = $('.panels.size11, .panels.size21, .panels.size22');
-      var currentClasses = $panels.attr('class');
-      var indexOfContainerClass = currentClasses.indexOf('panel-container');
+      var $container = $('[data-metro-id="' + data.id + '"]:not([data-mce-bogus] [data-metro-id="' + data.id + '"])').parent();
+      var containerWidth = $container.width();
+      var $panelsContainer = $container.find('.metro-panels ul');
 
-      if (indexOfContainerClass > -1) {
-        var styleToRemove = currentClasses.substring(indexOfContainerClass);
-        $panels.removeClass(styleToRemove);
-      }
+      $panelsContainer.removeClass();
 
       if (containerWidth >= 1300) {
-        $panels.addClass('panel-container-1300');
+        $panelsContainer.addClass('panel-container-1300');
       } else if (containerWidth >= 1200) {
-        $panels.addClass('panel-container-1200');
+        $panelsContainer.addClass('panel-container-1200');
       } else if (containerWidth >= 1024) {
-        $panels.addClass('panel-container-1024');
+        $panelsContainer.addClass('panel-container-1024');
       } else if (containerWidth >= 640) {
-        $panels.addClass('panel-container-640');
+        $panelsContainer.addClass('panel-container-640');
       } else if (containerWidth >= 400) {
-        $panels.addClass('panel-container-400');
+        $panelsContainer.addClass('panel-container-400');
       } else {
-        $panels.addClass('panel-container-initial');
+        $panelsContainer.addClass('panel-container-initial');
       }
     }
 


### PR DESCRIPTION
@sofiiakvasnevska

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6132

## Description
Added function which removes previous container style if there is any and adds new container style which depends on parent width. Function is called when metro is loaded or when resizing.

## Screenshots/screencasts
One example is without container, one with a container of max-width  600px.
https://streamable.com/81hd6y

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko @YaroslavOvdii