### PR TITLE
OD-326 [Fix] Grid components will be sized correctly.

### DIFF
--- a/vendor/freewall.js
+++ b/vendor/freewall.js
@@ -670,12 +670,12 @@
                             !items.length && 
                             (lastBlock && lastBlock.y == y) && 
                             (maxX - freeArea.width) <= 1) {
-                            block.width = maxX - lastBlock.width;
+                            block.width = Math.max(maxX - lastBlock.width, block.width);
                         } else if (block != null &&
                             !items.length &&
                             (maxX - freeArea.width) <= 1 &&
                             (block.width / maxX) > 0.5) {
-                            block.width = maxX;
+                            block.width = Math.max(maxX, block.width);
                         }
                     }
 


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://weboo.atlassian.net/browse/OD-326

## Description
This issue occurred because of this [part](https://github.com/Fliplet/fliplet-widget-metro/blob/master/vendor/freewall.js#L669).
Where `maxX` was zero (0). To ensure that element doesn't get a 0 width we use Math.max to get the biggest value.

## Screenshots/screencasts
https://share.getcloudapp.com/o0uq21mX

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@AndrRyaz @ivandevupp